### PR TITLE
Add support for R17

### DIFF
--- a/lib/toniq/keepalive_persistence.ex
+++ b/lib/toniq/keepalive_persistence.ex
@@ -93,7 +93,8 @@ defmodule Toniq.KeepalivePersistence do
 
   # This is not a API any production code should rely upon, but could be useful
   # info when debugging or to verify things in tests.
-  defp debug_info, do: %{ system_pid: System.get_pid, last_updated_at: :os.system_time }
+  defp debug_info, do: %{ system_pid: System.get_pid,
+                          last_updated_at: (:timer.now_diff :erlang.now, {0, 0, 0}) * 1000 }
 
   defp alive_key(identifier), do: "#{default_scope}:#{identifier}:alive"
   defp registered_vms_key,    do: "#{default_scope}:registered_vms"


### PR DESCRIPTION
R17 doesn't work because of `:os.system_time/0` call.
