### PR TITLE
add exredis and uuid to applications list

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ And run:
 
     mix deps.get
 
-Then add `:toniq` and `:uuid` to the list of applications in mix.exs.
+Then add `:toniq` to the list of applications in mix.exs.
 
 And configure toniq in different environments:
 

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Toniq.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger],
+    [applications: [:logger, :uuid, :exredis],
      mod: {Toniq, []}]
   end
 


### PR DESCRIPTION
this adds exredis and uuid to the list of application dependencies. basically this is needed for exrm releases, but it's also a good idea in general. see this recent post on the plataformatec blog: http://blog.plataformatec.com.br/2016/07/understanding-deps-and-applications-in-your-mixfile/
