### PR TITLE
Replace deprecated :erlang.now/0

### DIFF
--- a/lib/toniq/job_event.ex
+++ b/lib/toniq/job_event.ex
@@ -49,6 +49,11 @@ defmodule Toniq.JobEvent do
     notify {:failed, job}
   end
 
+  def error(job, error) do
+    job_with_error = Map.put(job, :error, error)
+    notify {:error, job_with_error}
+  end
+
   defp notify(event) do
     GenServer.cast(__MODULE__, {:notify, event})
   end

--- a/lib/toniq/job_runner.ex
+++ b/lib/toniq/job_runner.ex
@@ -45,6 +45,7 @@ defmodule Toniq.JobRunner do
   defp process_result({:job_has_failed, job, error}) do
     Toniq.JobPersistence.mark_as_failed(job, error)
     Logger.error "Job ##{job.id}: #{inspect(job.worker)}.perform(#{inspect(job.arguments)}) failed with error: #{inspect(error)}"
+    Toniq.JobEvent.error(job, error)
     Toniq.JobEvent.failed(job)
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,3 @@
-%{"eredis": {:hex, :eredis, "1.0.8"},
-  "exredis": {:hex, :exredis, "0.2.2"},
-  "uuid": {:hex, :uuid, "1.0.1"}}
+%{"eredis": {:hex, :eredis, "1.0.8", "ab4fda1c4ba7fbe6c19c26c249dc13da916d762502c4b4fa2df401a8d51c5364", [:rebar], []},
+  "exredis": {:hex, :exredis, "0.2.2", "f72159ce0625f622d05025bd8747769375079da932ea7980ab74f204ddbf2b18", [:mix], [{:eredis, ">= 1.0.8", [hex: :eredis, optional: false]}]},
+  "uuid": {:hex, :uuid, "1.0.1", "ebb032f2b429761540ca3e67436d1eb140206f139ddb7e1f2cc24b77cb4af45b", [:mix], []}}


### PR DESCRIPTION
When compiling toniq I get:

`warning: erlang:now/0: Deprecated BIF. See the "Time and Time Correction in Erlang" chapter of the ERTS User's Guide for more information.`
