### PR TITLE
Update README to include exredis as an explicit dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Add as a dependency in your mix.exs file:
 ```elixir
 defp deps do
   [
+    {:exredis, ">= 0.1.1"},
     {:toniq, "~> 1.0"}
   ]
 end
@@ -36,7 +37,7 @@ And run:
 
     mix deps.get
 
-Then add `:toniq` and `:uuid` to the list of applications in mix.exs.
+Then add `exredis`, `:toniq` and `:uuid` to the list of applications in mix.exs.
 
 And configure toniq in different environments:
 


### PR DESCRIPTION
Apparently `exredis` has to be included as an explicit dependency. Otherwise, the app will crash with the following error

`(UndefinedFunctionError) function Exredis.start_using_connection_string/1 is undefined (module Exredis is not available)`

This is true at least for `exrm` as `exredis` doesn't get copied across to the `lib` directory. This PR is simply to update the README to reflect that.

Let me know if this is unnecessary and whether I've missed something obvious.
