### PR TITLE
Add stacktrace to job error log message

### DIFF
--- a/lib/toniq/job_runner.ex
+++ b/lib/toniq/job_runner.ex
@@ -26,14 +26,14 @@ defmodule Toniq.JobRunner do
 
   defp retry_when_failing(status), do: retry_when_failing(status, 1)
   defp retry_when_failing({:job_was_successful, job}, _attempt), do: {:job_was_successful, job}
-  defp retry_when_failing({:job_has_failed, job, error}, attempt) do
+  defp retry_when_failing({:job_has_failed, job, error, stack}, attempt) do
     if retry_strategy.retry?(attempt) do
       :timer.sleep trunc(retry_strategy.ms_to_sleep_before(attempt))
 
       result = run_job(job)
       retry_when_failing(result, attempt + 1)
     else
-      {:job_has_failed, job, error}
+      {:job_has_failed, job, error, stack}
     end
   end
 
@@ -42,11 +42,20 @@ defmodule Toniq.JobRunner do
     Toniq.JobEvent.finished(job)
   end
 
-  defp process_result({:job_has_failed, job, error}) do
+  defp process_result({:job_has_failed, job, error, stack}) do
     Toniq.JobPersistence.mark_as_failed(job, error)
-    Logger.error "Job ##{job.id}: #{inspect(job.worker)}.perform(#{inspect(job.arguments)}) failed with error: #{inspect(error)}"
+    log_error(job, error, stack)
     Toniq.JobEvent.failed(job)
   end
 
   defp retry_strategy, do: Application.get_env(:toniq, :retry_strategy)
+
+  defp log_error(job, error, stack) do
+    stacktrace = Exception.format_stacktrace(stack)
+    job_details = "##{job.id}: #{inspect(job.worker)}.perform(#{inspect(job.arguments)})"
+
+    "Job #{job_details} failed with error: #{inspect(error)}\n\n#{stacktrace}"
+    |> String.trim
+    |> Logger.error
+  end
 end

--- a/test/toniq/job_process_test.exs
+++ b/test/toniq/job_process_test.exs
@@ -20,25 +20,32 @@ defmodule Toniq.JobProcessTest do
     end
   end
 
+  @stacktrace [{Toniq.JobProcessTest.TestErrorWorker, :perform, 1,
+                [file: 'test/toniq/job_process_test.exs', line: 13]},
+               {Toniq.JobProcess, :run_job_and_capture_result, 1,
+                [file: 'lib/toniq/job_process.ex', line: 25]},
+               {Toniq.JobProcess, :"-run_job/1-fun-0-", 2,
+                [file: 'lib/toniq/job_process.ex', line: 15]}]
+
   test "a successful job runs return {:job_was_successful, job}" do
     job = %{worker: TestSuccessWorker, arguments: [data: 10]}
     assert Toniq.JobProcess.run(job) == {:job_was_successful, job}
   end
 
-  test "a job that raises an error returns {:job_has_failed, job, error}" do
+  test "a job that raises an error returns {:job_has_failed, job, error, stack}" do
     job = %{worker: TestErrorWorker, arguments: [data: 10]}
-    assert Toniq.JobProcess.run(job) == {:job_has_failed, job, %RuntimeError{message: "fail"}}
+    assert Toniq.JobProcess.run(job) == {:job_has_failed, job, %RuntimeError{message: "fail"}, @stacktrace}
   end
 
-  test "a job that crashes returns {:job_has_failed, job, error}" do
+  test "a job that crashes returns {:job_has_failed, job, error, []}" do
     job = %{worker: TestCrashWorker, arguments: [data: 10]}
-    assert Toniq.JobProcess.run(job) == {:job_has_failed, job, %Toniq.JobProcess.CrashError{message: "The job runner crashed. The reason that was given is: simulate an unknown error"}}
+    assert Toniq.JobProcess.run(job) == {:job_has_failed, job, %Toniq.JobProcess.CrashError{message: "The job runner crashed. The reason that was given is: simulate an unknown error"}, []}
   end
 
   # regression
   test "when run twice, a failing job still returns job_has_failed" do
     job = %{worker: TestErrorWorker, arguments: [data: 10]}
-    assert Toniq.JobProcess.run(job) == {:job_has_failed, job, %RuntimeError{message: "fail"}}
-    assert Toniq.JobProcess.run(job) == {:job_has_failed, job, %RuntimeError{message: "fail"}}
+    assert Toniq.JobProcess.run(job) == {:job_has_failed, job, %RuntimeError{message: "fail"}, @stacktrace}
+    assert Toniq.JobProcess.run(job) == {:job_has_failed, job, %RuntimeError{message: "fail"}, @stacktrace}
   end
 end


### PR DESCRIPTION
Without this, it's harder to see why the job errored.

We can see the error, the job where the error happened, the args, but not where it happened.
