### PR TITLE
Add exredis application

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule Toniq.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger],
+    [applications: [:logger, :exredis],
      mod: {Toniq, []}]
   end
 


### PR DESCRIPTION
Without this, `mix release` warns:

```
==> One or more direct or transitive dependencies are missing from
    :applications or :included_applications, they will not be included
    in the release:

    :exredis

    This can cause your application to fail at runtime. If you are sure
    that this is not an issue, you may ignore this warning.
```
