### PR TITLE
Introduce the concept of delayed jobs

### DIFF
--- a/lib/toniq.ex
+++ b/lib/toniq.ex
@@ -10,7 +10,14 @@ defmodule Toniq do
     |> extract_data
     |> Toniq.enqueue_to(SendEmailWorker)
   """
-  def enqueue_to(arguments, worker_module), do: enqueue(worker_module, arguments)
+  def enqueue_to(arguments, worker_module, options \\ []) do
+    options
+    |> Keyword.get(:delay_for)
+    |> case do
+      nil -> enqueue(worker_module, arguments)
+      _   -> enqueue_with_delay(worker_module, arguments, options)
+    end
+  end
 
   @doc """
   Enqueue job to be run in the background as soon as possible
@@ -21,11 +28,11 @@ defmodule Toniq do
   end
 
   @doc """
-  Stores job in the delayed queue.
+  Enqueue job to be run in the background at a later time
   """
-  def delay_to(arguments, worker_module) do
+  def enqueue_with_delay(worker_module, arguments, options) do
     worker_module
-    |> Toniq.JobPersistence.store_delayed_job(arguments)
+    |> Toniq.JobPersistence.store_delayed_job(arguments, options)
   end
 
   @doc """

--- a/lib/toniq.ex
+++ b/lib/toniq.ex
@@ -33,6 +33,7 @@ defmodule Toniq do
   def enqueue_with_delay(worker_module, arguments, options) do
     worker_module
     |> Toniq.JobPersistence.store_delayed_job(arguments, options)
+    |> Toniq.DelayedJobTracker.register_job
   end
 
   @doc """
@@ -68,6 +69,7 @@ defmodule Toniq do
       worker(Toniq.Keepalive, []),
       worker(Toniq.Takeover, []),
       worker(Toniq.JobImporter, []),
+      worker(Toniq.DelayedJobTracker, [])
     ]
 
     # When one process fails we restart all of them to ensure a valid state. Jobs are then

--- a/lib/toniq.ex
+++ b/lib/toniq.ex
@@ -21,11 +21,11 @@ defmodule Toniq do
   end
 
   @doc """
-  Stores job in the suspended queue.
+  Stores job in the delayed queue.
   """
-  def suspend_to(arguments, worker_module) do
+  def delay_to(arguments, worker_module) do
     worker_module
-    |> Toniq.JobPersistence.store_suspended_job(arguments)
+    |> Toniq.JobPersistence.store_delayed_job(arguments)
   end
 
   @doc """

--- a/lib/toniq.ex
+++ b/lib/toniq.ex
@@ -21,6 +21,14 @@ defmodule Toniq do
   end
 
   @doc """
+  Stores job in the suspended queue.
+  """
+  def suspend_to(arguments, worker_module) do
+    worker_module
+    |> Toniq.JobPersistence.store_suspended_job(arguments)
+  end
+
+  @doc """
   List failed jobs
   """
   def failed_jobs do

--- a/lib/toniq.ex
+++ b/lib/toniq.ex
@@ -54,6 +54,11 @@ defmodule Toniq do
   """
   def delete(job), do: Toniq.JobPersistence.delete_failed_job(job)
 
+  @doc """
+  Flush all delayed jobs
+  """
+  def flush_delayed_jobs, do: Toniq.DelayedJobTracker.flush_all_jobs
+
   # See http://elixir-lang.org/docs/stable/elixir/Application.html
   # for more information on OTP Applications
   def start(_type, _args) do

--- a/lib/toniq/config.ex
+++ b/lib/toniq/config.ex
@@ -9,10 +9,11 @@ defmodule Toniq.Config do
     default :toniq,
       redis_key_prefix: :toniq,
       redis_url: "redis://localhost:6379/0",
-      keepalive_interval: 4000, # ms
-      keepalive_expiration: 10000, # ms
-      takeover_interval: 2000, # ms
-      job_import_interval: 2000, # ms
+      keepalive_interval: 4_000, # ms
+      keepalive_expiration: 10_000, # ms
+      takeover_interval: 2_000, # ms
+      job_import_interval: 2_000, # ms
+      delay_flush_interval: 100, # ms
       retry_strategy: Toniq.RetryWithIncreasingDelayStrategy
   end
 

--- a/lib/toniq/delayed_job_tracker.ex
+++ b/lib/toniq/delayed_job_tracker.ex
@@ -45,8 +45,11 @@ defmodule Toniq.DelayedJobTracker do
   end
 
   defp schedule_work do
-    Process.send_after(self(), :flush, 100)
+    self
+    |> Process.send_after(:flush, delay_flush_interval)
   end
+
+  defp delay_flush_interval, do: Application.get_env(:toniq, :delay_flush_interval)
 
   defp enqueue_expired_jobs(jobs) do
     jobs

--- a/lib/toniq/delayed_job_tracker.ex
+++ b/lib/toniq/delayed_job_tracker.ex
@@ -4,7 +4,7 @@ defmodule Toniq.DelayedJobTracker do
   alias Toniq.JobPersistence
 
   def start_link(name \\ __MODULE__) do
-    GenServer.start_link(__MODULE__, [], name: name)
+    GenServer.start_link(__MODULE__, JobPersistence.delayed_jobs, name: name)
   end
 
   def init(state) do

--- a/lib/toniq/delayed_job_tracker.ex
+++ b/lib/toniq/delayed_job_tracker.ex
@@ -1,0 +1,50 @@
+defmodule Toniq.DelayedJobTracker do
+  use GenServer
+
+  alias Toniq.JobPersistence
+
+  def start_link(name \\ __MODULE__) do
+    GenServer.start_link(__MODULE__, [], name: name)
+  end
+
+  def init(state) do
+    Process.send_after(self(), :flush, 100)
+    {:ok, state}
+  end
+
+  def register_job(job) do
+    GenServer.cast(__MODULE__, {:register_job, job})
+    job
+  end
+
+  def handle_call(:ping, _from, jobs) do
+    {:reply, jobs, jobs}
+  end
+
+  def handle_cast({:register_job, job}, delayed_jobs) do
+    {:noreply, [job | delayed_jobs]}
+  end
+
+  def handle_info(:flush, delayed_jobs) do
+    Process.send_after(self(), :flush, 100)
+
+    delayed_jobs
+    |> enqueue_expired_jobs
+    |> remaining_jobs_from(delayed_jobs)
+  end
+
+  defp enqueue_expired_jobs(jobs) do
+    jobs
+    |> Stream.filter(&(&1.delayed_until <= :os.system_time(:milli_seconds)))
+    |> Enum.map(&(JobPersistence.move_delayed_job_to_incoming_jobs(&1)))
+  end
+
+  defp remaining_jobs_from(expired_jobs, all_jobs) do
+    remaining_jobs = all_jobs
+      |> MapSet.new
+      |> MapSet.difference(MapSet.new(expired_jobs))
+      |> MapSet.to_list
+
+    {:noreply, remaining_jobs}
+  end
+end

--- a/lib/toniq/delayed_job_tracker.ex
+++ b/lib/toniq/delayed_job_tracker.ex
@@ -31,7 +31,7 @@ defmodule Toniq.DelayedJobTracker do
 
   def handle_cast({:flush_all_jobs}, delayed_jobs) do
     delayed_jobs
-    |> Enum.each(&JobPersistence.move_delayed_job_to_incoming_jobs(&1))
+    |> Enum.each(&JobPersistence.move_delayed_job_to_incoming_jobs/1)
 
     {:noreply, []}
   end
@@ -51,7 +51,7 @@ defmodule Toniq.DelayedJobTracker do
   defp enqueue_expired_jobs(jobs) do
     jobs
     |> Stream.filter(&has_expired?/1)
-    |> Enum.map(&(JobPersistence.move_delayed_job_to_incoming_jobs(&1)))
+    |> Enum.map(&JobPersistence.move_delayed_job_to_incoming_jobs/1)
   end
 
   defp remaining_jobs_from(expired_jobs, all_jobs) do

--- a/lib/toniq/delayed_job_tracker.ex
+++ b/lib/toniq/delayed_job_tracker.ex
@@ -17,12 +17,23 @@ defmodule Toniq.DelayedJobTracker do
     job
   end
 
+  def flush_all_jobs do
+    GenServer.cast(__MODULE__, {:flush_all_jobs})
+  end
+
   def handle_call(:ping, _from, jobs) do
     {:reply, jobs, jobs}
   end
 
   def handle_cast({:register_job, job}, delayed_jobs) do
     {:noreply, [job | delayed_jobs]}
+  end
+
+  def handle_cast({:flush_all_jobs}, delayed_jobs) do
+    delayed_jobs
+    |> Enum.each(&JobPersistence.move_delayed_job_to_incoming_jobs(&1))
+
+    {:noreply, []}
   end
 
   def handle_info(:flush, delayed_jobs) do

--- a/lib/toniq/job.ex
+++ b/lib/toniq/job.ex
@@ -2,8 +2,9 @@ defmodule Toniq.Job do
   # NOTE: If the format changes: add migration code for older formats
   @job_format_version 1
 
-  def build(id, worker_module, arguments) do
+  def build(id, worker_module, arguments, options \\ []) do
     %{id: id, worker: worker_module, arguments: arguments, version: @job_format_version}
+    |> add_delay(options)
   end
 
   def migrate(job), do: migrate_v0_jobs_to_v1(job)
@@ -27,4 +28,15 @@ defmodule Toniq.Job do
       {:changed, map, v1}
     end
   end
+
+  defp add_delay(job, options) do
+    options
+    |> Keyword.get(:delay_for)
+    |> case do
+      nil   -> job
+      delay -> job |> Map.put(:delayed_until, delay |> to_expiry)
+    end
+  end
+
+  defp to_expiry(delay), do: :os.system_time(:milli_seconds) + delay
 end

--- a/lib/toniq/job.ex
+++ b/lib/toniq/job.ex
@@ -38,5 +38,6 @@ defmodule Toniq.Job do
     end
   end
 
+  defp to_expiry(:infinity), do: :infinity
   defp to_expiry(delay), do: :os.system_time(:milli_seconds) + delay
 end

--- a/lib/toniq/job_persistence.ex
+++ b/lib/toniq/job_persistence.ex
@@ -16,8 +16,8 @@ defmodule Toniq.JobPersistence do
   @doc """
   Stores a delayed job in redis.
   """
-  def store_delayed_job(worker_module, arguments, identifier \\ default_identifier) do
-    store_job_in_key(worker_module, arguments, delayed_jobs_key(identifier), identifier)
+  def store_delayed_job(worker_module, arguments, options, identifier \\ default_identifier) do
+    store_job_in_key(worker_module, arguments, delayed_jobs_key(identifier), identifier, options)
   end
 
   # Only used internally by JobImporter
@@ -128,10 +128,10 @@ defmodule Toniq.JobPersistence do
     identifier_scoped_key :incoming_jobs, identifier
   end
 
-  defp store_job_in_key(worker_module, arguments, key, identifier) do
+  defp store_job_in_key(worker_module, arguments, key, identifier, options \\ []) do
     job_id = redis |> incr(counter_key)
 
-    job = Toniq.Job.build(job_id, worker_module, arguments) |> add_vm_identifier(identifier)
+    job = Toniq.Job.build(job_id, worker_module, arguments, options) |> add_vm_identifier(identifier)
     redis |> sadd(key, strip_vm_identifier(job))
     job
   end

--- a/lib/toniq/keepalive_persistence.ex
+++ b/lib/toniq/keepalive_persistence.ex
@@ -47,11 +47,20 @@ defmodule Toniq.KeepalivePersistence do
         failed_jobs_key(to_identifier),
       ],
 
+      # Move suspended jobs
+      [
+        "SUNIONSTORE",
+        suspended_jobs_key(to_identifier),
+        suspended_jobs_key(from_identifier),
+        suspended_jobs_key(to_identifier),
+      ],
+
       # Remove orphaned job lists
       [
         "DEL",
         jobs_key(from_identifier),
         failed_jobs_key(from_identifier),
+        suspended_jobs_key(from_identifier),
         incoming_jobs_key(from_identifier)
       ],
 
@@ -80,6 +89,10 @@ defmodule Toniq.KeepalivePersistence do
 
   defp failed_jobs_key(identifier) do
     Toniq.JobPersistence.failed_jobs_key(identifier)
+  end
+
+  defp suspended_jobs_key(identifier) do
+    Toniq.JobPersistence.suspended_jobs_key(identifier)
   end
 
   defp redis_query(query) do

--- a/lib/toniq/keepalive_persistence.ex
+++ b/lib/toniq/keepalive_persistence.ex
@@ -44,15 +44,15 @@ defmodule Toniq.KeepalivePersistence do
         "SUNIONSTORE",
         failed_jobs_key(to_identifier),
         failed_jobs_key(from_identifier),
-        failed_jobs_key(to_identifier),
+        failed_jobs_key(to_identifier)
       ],
 
-      # Move suspended jobs
+      # Move delayed jobs
       [
         "SUNIONSTORE",
-        suspended_jobs_key(to_identifier),
-        suspended_jobs_key(from_identifier),
-        suspended_jobs_key(to_identifier),
+        delayed_jobs_key(to_identifier),
+        delayed_jobs_key(from_identifier),
+        delayed_jobs_key(to_identifier)
       ],
 
       # Remove orphaned job lists
@@ -60,7 +60,7 @@ defmodule Toniq.KeepalivePersistence do
         "DEL",
         jobs_key(from_identifier),
         failed_jobs_key(from_identifier),
-        suspended_jobs_key(from_identifier),
+        delayed_jobs_key(from_identifier),
         incoming_jobs_key(from_identifier)
       ],
 
@@ -91,8 +91,8 @@ defmodule Toniq.KeepalivePersistence do
     Toniq.JobPersistence.failed_jobs_key(identifier)
   end
 
-  defp suspended_jobs_key(identifier) do
-    Toniq.JobPersistence.suspended_jobs_key(identifier)
+  defp delayed_jobs_key(identifier) do
+    Toniq.JobPersistence.delayed_jobs_key(identifier)
   end
 
   defp redis_query(query) do

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,8 @@ defmodule Toniq.Mixfile do
     [
       {:exredis, ">= 0.1.1"},
       {:uuid, "~> 1.0"},
-      {:ex_doc, ">= 0.0.0", only: :dev}
+      {:ex_doc, ">= 0.0.0", only: :dev},
+      {:retry, "~> 0.5.0", only: :test}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -2,4 +2,5 @@
   "eredis": {:hex, :eredis, "1.0.8", "ab4fda1c4ba7fbe6c19c26c249dc13da916d762502c4b4fa2df401a8d51c5364", [:rebar], []},
   "ex_doc": {:hex, :ex_doc, "0.13.1", "658dbfc8cc5b0fac192f0f3254efe66ee6294200804a291549e0aeb052053bba", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "exredis": {:hex, :exredis, "0.2.2", "f72159ce0625f622d05025bd8747769375079da932ea7980ab74f204ddbf2b18", [:mix], [{:eredis, ">= 1.0.8", [hex: :eredis, optional: false]}]},
+  "retry": {:hex, :retry, "0.5.0", "61ce3cca636370a7f630272ab5f965dd204d8ac6076a57bf9eca934bcaeec8ec", [:mix], []},
   "uuid": {:hex, :uuid, "1.0.1", "ebb032f2b429761540ca3e67436d1eb140206f139ddb7e1f2cc24b77cb4af45b", [:mix], []}}

--- a/test/toniq/delayed_job_tracker_test.exs
+++ b/test/toniq/delayed_job_tracker_test.exs
@@ -1,0 +1,30 @@
+defmodule Toniq.DelayedJobTrackerTest do
+  use ExUnit.Case
+
+  alias Toniq.{DelayedJobTracker, JobPersistence}
+
+  defmodule TestWorker do
+    use Toniq.Worker
+
+    def perform(_) do
+    end
+  end
+
+  test "can register and flush delayed jobs" do
+    DelayedJobTracker.start_link(:test_delayed_job_tracker)
+
+    TestWorker
+    |> JobPersistence.store_delayed_job(%{some: "data"}, delay_for: 500)
+    |> DelayedJobTracker.register_job
+
+    TestWorker
+    |> JobPersistence.store_delayed_job(%{some: "data"}, delay_for: 500)
+    |> DelayedJobTracker.register_job
+
+    assert JobPersistence.delayed_jobs |> Enum.count == 2
+
+    :timer.sleep(1_000)
+
+    assert JobPersistence.delayed_jobs |> Enum.empty?
+  end
+end

--- a/test/toniq/delayed_job_tracker_test.exs
+++ b/test/toniq/delayed_job_tracker_test.exs
@@ -10,6 +10,11 @@ defmodule Toniq.DelayedJobTrackerTest do
     end
   end
 
+  setup do
+    Process.whereis(:toniq_redis) |> Exredis.query([ "FLUSHDB" ])
+    :ok
+  end
+
   test "can register and flush delayed jobs" do
     DelayedJobTracker.start_link(:test_delayed_job_tracker)
 
@@ -26,5 +31,23 @@ defmodule Toniq.DelayedJobTrackerTest do
     :timer.sleep(1_000)
 
     assert JobPersistence.delayed_jobs |> Enum.empty?
+  end
+
+  test "doesn't flush jobs that are delayed indefinitely" do
+    DelayedJobTracker.start_link(:test_delayed_job_tracker)
+
+    TestWorker
+    |> JobPersistence.store_delayed_job(%{some: "data"}, delay_for: :infinity)
+    |> DelayedJobTracker.register_job
+
+    TestWorker
+    |> JobPersistence.store_delayed_job(%{some: "data"}, delay_for: :infinity)
+    |> DelayedJobTracker.register_job
+
+    assert JobPersistence.delayed_jobs |> Enum.count == 2
+
+    :timer.sleep(1_000)
+
+    assert JobPersistence.delayed_jobs |> Enum.count == 2
   end
 end

--- a/test/toniq/job_persistence_test.exs
+++ b/test/toniq/job_persistence_test.exs
@@ -30,7 +30,7 @@ defmodule Exredis.JobPersistenceTest do
   end
 
   test "can store and move a delayed a job" do
-    job = Toniq.JobPersistence.store_delayed_job(SomeWorker, some: "data")
+    job = Toniq.JobPersistence.store_delayed_job(SomeWorker, %{some: "data"}, [delay_for: 500])
     assert Toniq.JobPersistence.delayed_jobs == [job]
 
     Toniq.JobPersistence.move_delayed_job_to_incoming_jobs(job)

--- a/test/toniq/job_persistence_test.exs
+++ b/test/toniq/job_persistence_test.exs
@@ -7,6 +7,10 @@ defmodule Exredis.JobPersistenceTest do
   end
 
   defmodule SomeWorker do
+    use Toniq.Worker
+
+    def perform(_) do
+    end
   end
 
   test "can persist job state" do

--- a/test/toniq/job_persistence_test.exs
+++ b/test/toniq/job_persistence_test.exs
@@ -29,13 +29,13 @@ defmodule Exredis.JobPersistenceTest do
     assert Toniq.JobPersistence.failed_jobs == []
   end
 
-  test "can store and move a suspended a job" do
-    job = Toniq.JobPersistence.store_suspended_job(SomeWorker, some: "data")
-    assert Toniq.JobPersistence.suspended_jobs == [job]
+  test "can store and move a delayed a job" do
+    job = Toniq.JobPersistence.store_delayed_job(SomeWorker, some: "data")
+    assert Toniq.JobPersistence.delayed_jobs == [job]
 
-    Toniq.JobPersistence.move_suspended_job_to_incoming_jobs(job)
+    Toniq.JobPersistence.move_delayed_job_to_incoming_jobs(job)
     assert Toniq.JobPersistence.incoming_jobs == [job]
-    assert Toniq.JobPersistence.suspended_jobs == []
+    assert Toniq.JobPersistence.delayed_jobs == []
   end
 
   test "can store and retrieve incoming jobs" do

--- a/test/toniq/job_persistence_test.exs
+++ b/test/toniq/job_persistence_test.exs
@@ -29,6 +29,15 @@ defmodule Exredis.JobPersistenceTest do
     assert Toniq.JobPersistence.failed_jobs == []
   end
 
+  test "can store and move a suspended a job" do
+    job = Toniq.JobPersistence.store_suspended_job(SomeWorker, some: "data")
+    assert Toniq.JobPersistence.suspended_jobs == [job]
+
+    Toniq.JobPersistence.move_suspended_job_to_incoming_jobs(job)
+    assert Toniq.JobPersistence.incoming_jobs == [job]
+    assert Toniq.JobPersistence.suspended_jobs == []
+  end
+
   test "can store and retrieve incoming jobs" do
     job = Toniq.JobPersistence.store_incoming_job(SomeWorker, incoming: "take cover")
     assert Toniq.JobPersistence.incoming_jobs == [job]

--- a/test/toniq/job_test.exs
+++ b/test/toniq/job_test.exs
@@ -1,0 +1,23 @@
+defmodule Toniq.JobTest do
+  use ExUnit.Case
+
+  defmodule SomeWorker do
+  end
+
+  test "builds a job without options" do
+    job = Toniq.Job.build(42, SomeWorker, %{some: "data"})
+
+    assert job == %{id: 42, worker: SomeWorker, arguments: %{some: "data"}, version: 1}
+  end
+
+  test "builds a job with a delay" do
+    job = Toniq.Job.build(42, SomeWorker, %{some: "data"}, delay_for: 3_000)
+    expiry = :os.system_time(:milli_seconds) + 3_000
+
+    assert job.id == 42
+    assert job.worker == SomeWorker
+    assert job.arguments == %{some: "data"}
+    assert job.version == 1
+    assert_in_delta(job.delayed_until, expiry, 10)
+  end
+end

--- a/test/toniq_test.exs
+++ b/test/toniq_test.exs
@@ -50,6 +50,7 @@ defmodule ToniqTest do
   setup do
     Toniq.JobEvent.subscribe
     Process.register(self, :toniq_test)
+    Process.whereis(:toniq_redis) |> Exredis.query([ "FLUSHDB" ])
     on_exit &Toniq.JobEvent.unsubscribe/0
   end
 


### PR DESCRIPTION
As per our conversation, here's a summary of how it works:

1. You can queue a job with a delay by calling `Toniq.enqueue_with_delay/3`
2. The delay can be for a specific period (in milliseconds) or indefinite (`:infinity`)
3. There's a `GenServer` called `DelayedJobTracker` that tracks delayed jobs and flushes them when they expire
4. You can also optionally flush all delayed jobs regardless of whether they've expired or not

I'll update the README once you've accepted the PR.