### PR TITLE
Fix compiler warnings and minor simplification of DelayedJobTracker 

### DIFF
--- a/lib/toniq/delayed_job_tracker.ex
+++ b/lib/toniq/delayed_job_tracker.ex
@@ -66,11 +66,7 @@ defmodule Toniq.DelayedJobTracker do
   end
 
   defp remaining_jobs_from(expired_jobs, all_jobs) do
-    remaining_jobs = all_jobs
-      |> MapSet.new
-      |> MapSet.difference(MapSet.new(expired_jobs))
-      |> MapSet.to_list
-
+    remaining_jobs = all_jobs -- expired_jobs
     {:noreply, remaining_jobs}
   end
 

--- a/lib/toniq/delayed_job_tracker.ex
+++ b/lib/toniq/delayed_job_tracker.ex
@@ -29,10 +29,6 @@ defmodule Toniq.DelayedJobTracker do
     {:noreply, JobPersistence.delayed_jobs}
   end
 
-  def handle_call(:ping, _from, jobs) do
-    {:reply, jobs, jobs}
-  end
-
   def handle_cast({:register_job, job}, delayed_jobs) do
     {:noreply, [job | delayed_jobs]}
   end
@@ -42,6 +38,10 @@ defmodule Toniq.DelayedJobTracker do
     |> Enum.each(&JobPersistence.move_delayed_job_to_incoming_jobs/1)
 
     {:noreply, []}
+  end
+
+  def handle_call(:ping, _from, jobs) do
+    {:reply, jobs, jobs}
   end
 
   def handle_info(:flush, delayed_jobs) do

--- a/lib/toniq/job.ex
+++ b/lib/toniq/job.ex
@@ -21,8 +21,8 @@ defmodule Toniq.Job do
         version: @job_format_version,
       }
 
-      if Map.get(map, :error) do
-        v1 = Map.put(v1, :error, map.error)
+      v1 = if Map.get(map, :error) do
+        Map.put(v1, :error, map.error)
       end
 
       {:changed, map, v1}

--- a/lib/toniq/job.ex
+++ b/lib/toniq/job.ex
@@ -18,12 +18,10 @@ defmodule Toniq.Job do
         id: map.id,
         worker: map.worker,
         arguments: map.opts,
-        version: @job_format_version,
+        version: @job_format_version
       }
 
-      v1 = if Map.get(map, :error) do
-        Map.put(v1, :error, map.error)
-      end
+      v1 = if Map.get(map, :error), do: Map.put(v1, :error, map.error), else: v1
 
       {:changed, map, v1}
     end


### PR DESCRIPTION
I've fixed a couple compiler warnings that have been bugging me for a while. There's one remaining warning related to the deprecated `erlang:now/0` function, but I've decided to leave it as is since the comment suggests it's there for a reason.

I've also simplified and optimized remaining jobs calculation in `DelayedJobTracker`.