### PR TITLE
Fix JobProcess crash caused by non-string errors

### DIFF
--- a/lib/toniq/job_process.ex
+++ b/lib/toniq/job_process.ex
@@ -37,7 +37,7 @@ defmodule Toniq.JobProcess do
         wait_for_result()
       {:DOWN, _ref, :process, _pid, error} -> # Failed beause the process crashed
         crash_error =
-          "The job runner crashed. The reason that was given is: #{error}"
+          "The job runner crashed. The reason that was given is: #{inspect(error)}"
           |> wrap_in_crash_error
 
         {crash_error, []}


### PR DESCRIPTION
Sometimes when the process crashes, it receives a non-string error (tuple, map, struct, etc), which can't be logged without `inspect`. This causes `JobProcess` to crash and restart endlessly. 

This PR fixes the above issue. 