### PR TITLE
update exredis version in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add as a dependency in your mix.exs file:
 ```elixir
 defp deps do
   [
-    {:exredis, ">= 0.1.1"},
+    {:exredis, ">= 0.2.4"},
     {:toniq, "~> 1.0"}
   ]
 end


### PR DESCRIPTION
The current docs specify `0.1.1`, which spews out deprecation warnings for Elixir ~1.4:

```
==> exredis
Compiling 5 files (.ex)
warning: variable "settings" does not exist and is being expanded to "settings()", please use parentheses to remove the ambiguity or change the variable name
  lib/exredis/config.ex:23

warning: Dict.put/3 is deprecated, use the Map module for working with maps or the Keyword module for working with keyword lists
  lib/exredis/config.ex:78

warning: variable "defaultclient" does not exist and is being expanded to "defaultclient()", please use parentheses to remove the ambiguity or change the variable name
  lib/exredis/api.ex:40

warning: variable "defaultclient" does not exist and is being expanded to "defaultclient()", please use parentheses to remove the ambiguity or change the variable name
  lib/exredis/api.ex:41
(etc)
```

I'm not sure if they made breaking changes in the API, but so far I haven't had any problems.