### PR TITLE
Create %Toniq.Job{} struct instead using a map

### DIFF
--- a/lib/toniq.ex
+++ b/lib/toniq.ex
@@ -23,7 +23,9 @@ defmodule Toniq do
   Enqueue job to be run in the background as soon as possible
   """
   def enqueue(worker_module, arguments \\ []) do
-    Toniq.JobPersistence.store_job(worker_module, arguments)
+    worker_module
+    |> Toniq.Job.new(arguments)
+    |> Toniq.JobPersistence.store_job()
     |> Toniq.JobRunner.register_job()
   end
 
@@ -32,7 +34,8 @@ defmodule Toniq do
   """
   def enqueue_with_delay(worker_module, arguments, options) do
     worker_module
-    |> Toniq.JobPersistence.store_delayed_job(arguments, options)
+    |> Toniq.Job.new(arguments, options)
+    |> Toniq.JobPersistence.store_delayed_job()
     |> Toniq.DelayedJobTracker.register_job()
   end
 

--- a/lib/toniq/delayed_job_tracker.ex
+++ b/lib/toniq/delayed_job_tracker.ex
@@ -70,7 +70,12 @@ defmodule Toniq.DelayedJobTracker do
     {:noreply, remaining_jobs}
   end
 
+  defp has_expired?(%{options: nil}), do: true
   defp has_expired?(job) do
-    job.delayed_until != :infinity and job.delayed_until <= :os.system_time(:milli_seconds)
+    delayed_until = Keyword.get(job.options, :delayed_until)
+
+    delayed_until != nil
+    and delayed_until != :infinity
+    and delayed_until <= :os.system_time(:milli_seconds)
   end
 end

--- a/lib/toniq/job.ex
+++ b/lib/toniq/job.ex
@@ -15,6 +15,8 @@ defmodule Toniq.Job do
   ]
 
   def new(worker_module, arguments, options \\ nil) do
+    unless Code.ensure_loaded?(worker_module), do: raise "Worker not exists"
+
     %Job{
       worker: worker_module,
       arguments: arguments,

--- a/lib/toniq/job.ex
+++ b/lib/toniq/job.ex
@@ -2,10 +2,32 @@ defmodule Toniq.Job do
   # NOTE: If the format changes: add migration code for older formats
   @job_format_version 1
 
-  def build(id, worker_module, arguments, options \\ []) do
-    %{id: id, worker: worker_module, arguments: arguments, version: @job_format_version}
-    |> add_delay(options)
+  alias Toniq.Job
+
+  defstruct [
+    :id,
+    :worker,
+    :arguments,
+    :version,
+    :options,
+    :vm,
+    :error
+  ]
+
+  def new(worker_module, arguments, options \\ nil) do
+    %Job{
+      worker: worker_module,
+      arguments: arguments,
+      version: @job_format_version,
+      options: add_delay(options)
+    }
   end
+
+  def set_id(job, id), do: %{job | id: id}
+
+  def add_vm_identifier(job, identifier), do: %{job | vm: identifier}
+
+  def set_error(job, error), do: %{job | error: error}
 
   def migrate(job), do: migrate_v0_jobs_to_v1(job)
 
@@ -35,12 +57,13 @@ defmodule Toniq.Job do
     end
   end
 
-  defp add_delay(job, options) do
+  defp add_delay(nil), do: nil
+  defp add_delay(options) do
     options
     |> Keyword.get(:delay_for)
     |> case do
-      nil -> job
-      delay -> job |> Map.put(:delayed_until, delay |> to_expiry)
+      nil -> options
+      delay -> Keyword.put(options, :delayed_until, delay |> to_expiry)
     end
   end
 

--- a/test/toniq/delayed_job_tracker_test.exs
+++ b/test/toniq/delayed_job_tracker_test.exs
@@ -2,7 +2,7 @@ defmodule Toniq.DelayedJobTrackerTest do
   use ExUnit.Case
   use Retry
 
-  alias Toniq.{DelayedJobTracker, JobPersistence}
+  alias Toniq.{DelayedJobTracker, JobPersistence, Job}
 
   defmodule TestWorker do
     use Toniq.Worker
@@ -18,10 +18,12 @@ defmodule Toniq.DelayedJobTrackerTest do
 
   test "imports delayed jobs on start" do
     TestWorker
-    |> JobPersistence.store_delayed_job(%{some: "data"}, delay_for: 250)
+    |> Job.new(%{some: "data"}, delay_for: 250)
+    |> JobPersistence.store_delayed_job()
 
     TestWorker
-    |> JobPersistence.store_delayed_job(%{some: "data"}, delay_for: 500)
+    |> Job.new([some: "data"], [delay_for: 500])
+    |> JobPersistence.store_delayed_job()
 
     assert JobPersistence.delayed_jobs() |> Enum.count() == 2
 
@@ -34,7 +36,8 @@ defmodule Toniq.DelayedJobTrackerTest do
 
   test "imports delayed jobs on takeover (it calls reload_job_list)" do
     TestWorker
-    |> JobPersistence.store_delayed_job(%{some: "data"}, delay_for: 250)
+    |> Job.new([some: "data"],  [delay_for: 250])
+    |> JobPersistence.store_delayed_job()
 
     assert JobPersistence.delayed_jobs() |> Enum.count() == 1
 
@@ -49,11 +52,13 @@ defmodule Toniq.DelayedJobTrackerTest do
     DelayedJobTracker.start_link(:test_delayed_job_tracker)
 
     TestWorker
-    |> JobPersistence.store_delayed_job(%{some: "data"}, delay_for: 250)
+    |> Job.new([some: "data"], [delay_for: 250])
+    |> JobPersistence.store_delayed_job()
     |> DelayedJobTracker.register_job()
 
     TestWorker
-    |> JobPersistence.store_delayed_job(%{some: "data"}, delay_for: 500)
+    |> Job.new([some: "data"], [delay_for: 500])
+    |> JobPersistence.store_delayed_job()
     |> DelayedJobTracker.register_job()
 
     assert JobPersistence.delayed_jobs() |> Enum.count() == 2
@@ -67,11 +72,13 @@ defmodule Toniq.DelayedJobTrackerTest do
     DelayedJobTracker.start_link(:test_delayed_job_tracker)
 
     TestWorker
-    |> JobPersistence.store_delayed_job(%{some: "data"}, delay_for: :infinity)
+    |> Job.new([some: "data"], [delay_for: :infinity])
+    |> JobPersistence.store_delayed_job()
     |> DelayedJobTracker.register_job()
 
     TestWorker
-    |> JobPersistence.store_delayed_job(%{some: "data"}, delay_for: :infinity)
+    |> Job.new([some: "data"], [delay_for: :infinity])
+    |> JobPersistence.store_delayed_job()
     |> DelayedJobTracker.register_job()
 
     assert JobPersistence.delayed_jobs() |> Enum.count() == 2
@@ -85,11 +92,13 @@ defmodule Toniq.DelayedJobTrackerTest do
     DelayedJobTracker.start_link(:test_delayed_job_tracker)
 
     TestWorker
-    |> JobPersistence.store_delayed_job(%{some: "data"}, delay_for: :infinity)
+    |> Job.new([some: "data"], [delay_for: :infinity])
+    |> JobPersistence.store_delayed_job()
     |> DelayedJobTracker.register_job()
 
     TestWorker
-    |> JobPersistence.store_delayed_job(%{some: "data"}, delay_for: 10_000)
+    |> Job.new(%{some: "data"}, delay_for: 10_000)
+    |> JobPersistence.store_delayed_job()
     |> DelayedJobTracker.register_job()
 
     assert JobPersistence.delayed_jobs() |> Enum.count() == 2

--- a/test/toniq/failover_test.exs
+++ b/test/toniq/failover_test.exs
@@ -1,6 +1,7 @@
 # Ensure we can failover jobs from one VM to another when it exits or crashes
 defmodule Toniq.FailoverTest do
   use ExUnit.Case
+  alias Toniq.Job
 
   setup do
     Process.whereis(:toniq_redis) |> Exredis.query(["FLUSHDB"])
@@ -40,7 +41,9 @@ defmodule Toniq.FailoverTest do
   end
 
   defp add_job(identifier) do
-    Toniq.JobPersistence.store_job(FakeWorker, [], identifier)
+    FakeWorker
+    |> Job.new([])
+    |> Toniq.JobPersistence.store_job(identifier)
   end
 
   defp start_keepalive(name) do

--- a/test/toniq/job_importer_test.exs
+++ b/test/toniq/job_importer_test.exs
@@ -1,5 +1,6 @@
 defmodule Exredis.JobImporterTest do
   use ExUnit.Case
+  alias Toniq.Job
 
   defmodule TestWorker do
     use Toniq.Worker
@@ -17,7 +18,9 @@ defmodule Exredis.JobImporterTest do
   @tag :capture_log
   test "imports jobs from the incoming_jobs queue" do
     Process.register(self(), :toniq_job_importer_test)
-    Toniq.JobPersistence.store_incoming_job(TestWorker, data: 10)
+    TestWorker
+    |> Job.new([])
+    |> Toniq.JobPersistence.store_incoming_job()
 
     assert_receive :job_has_been_run, 1000
     # wait for job to be removed

--- a/test/toniq/job_runner_test.exs
+++ b/test/toniq/job_runner_test.exs
@@ -1,5 +1,6 @@
 defmodule Toniq.JobRunnerTest do
   use ExUnit.Case
+  alias Toniq.Job
 
   defmodule TestWorker do
     use Toniq.Worker
@@ -18,7 +19,7 @@ defmodule Toniq.JobRunnerTest do
   end
 
   test "can run a job and report it as successful" do
-    job = %{id: 1, worker: TestWorker, arguments: :succeed}
+    job = %Job{id: 1, worker: TestWorker, arguments: :succeed}
 
     Toniq.JobRunner.register_job(job)
 
@@ -27,7 +28,7 @@ defmodule Toniq.JobRunnerTest do
 
   @tag :capture_log
   test "can run a job and report it as failed" do
-    job = %{id: 1, worker: TestWorker, arguments: :fail}
+    job = %Job{id: 1, worker: TestWorker, arguments: :fail}
 
     Toniq.JobRunner.register_job(job)
 
@@ -37,8 +38,8 @@ defmodule Toniq.JobRunnerTest do
   # The job processor caught a gen_server message, didn't
   # seem like a problem at the time. Don't do that :)
   test "regression: can run two jobs in a row" do
-    job1 = %{id: 1, worker: TestWorker, arguments: :succeed}
-    job2 = %{id: 2, worker: TestWorker, arguments: :succeed}
+    job1 = %Job{id: 1, worker: TestWorker, arguments: :succeed}
+    job2 = %Job{id: 2, worker: TestWorker, arguments: :succeed}
 
     Toniq.JobRunner.register_job(job1)
     Toniq.JobRunner.register_job(job2)

--- a/test/toniq/job_test.exs
+++ b/test/toniq/job_test.exs
@@ -1,23 +1,29 @@
 defmodule Toniq.JobTest do
   use ExUnit.Case
+  alias Toniq.Job
 
   defmodule SomeWorker do
   end
 
   test "builds a job without options" do
-    job = Toniq.Job.build(42, SomeWorker, %{some: "data"})
+    job = Job.new(SomeWorker, %{some: "data"})
 
-    assert job == %{id: 42, worker: SomeWorker, arguments: %{some: "data"}, version: 1}
+    assert job == %Job{
+      worker: SomeWorker,
+      arguments: %{some: "data"},
+      version: 1,
+      options: nil
+    }
   end
 
   test "builds a job with a delay" do
-    job = Toniq.Job.build(42, SomeWorker, %{some: "data"}, delay_for: 3_000)
+    job = Job.new(SomeWorker, %{some: "data"}, delay_for: 3_000)
     expiry = :os.system_time(:milli_seconds) + 3_000
 
-    assert job.id == 42
+    assert job.id == nil
     assert job.worker == SomeWorker
     assert job.arguments == %{some: "data"}
     assert job.version == 1
-    assert_in_delta(job.delayed_until, expiry, 10)
+    assert_in_delta(Keyword.get(job.options, :delayed_until), expiry, 10)
   end
 end

--- a/test/toniq/takeover_test.exs
+++ b/test/toniq/takeover_test.exs
@@ -1,5 +1,6 @@
 defmodule Exredis.TakeoverTest do
   use ExUnit.Case
+  alias Toniq.Job
 
   setup do
     Process.whereis(:toniq_redis) |> Exredis.query(["FLUSHDB"])
@@ -57,11 +58,15 @@ defmodule Exredis.TakeoverTest do
   end
 
   defp add_incoming_job(identifier) do
-    Toniq.JobPersistence.store_incoming_job(FakeWorker, [], identifier)
+    FakeWorker
+    |> Job.new([])
+    |> Toniq.JobPersistence.store_incoming_job(identifier)
   end
 
   defp add_job(identifier) do
-    Toniq.JobPersistence.store_job(FakeWorker, [], identifier)
+    FakeWorker
+    |> Job.new([])
+    |> Toniq.JobPersistence.store_job(identifier)
   end
 
   defp add_failed_job(identifier) do

--- a/test/toniq/takeover_test.exs
+++ b/test/toniq/takeover_test.exs
@@ -2,6 +2,13 @@ defmodule Exredis.TakeoverTest do
   use ExUnit.Case
   alias Toniq.Job
 
+  defmodule TestWorker do
+    use Toniq.Worker
+
+    def perform do
+    end
+  end
+
   setup do
     Process.whereis(:toniq_redis) |> Exredis.query(["FLUSHDB"])
 
@@ -58,13 +65,13 @@ defmodule Exredis.TakeoverTest do
   end
 
   defp add_incoming_job(identifier) do
-    FakeWorker
+    TestWorker
     |> Job.new([])
     |> Toniq.JobPersistence.store_incoming_job(identifier)
   end
 
   defp add_job(identifier) do
-    FakeWorker
+    TestWorker
     |> Job.new([])
     |> Toniq.JobPersistence.store_job(identifier)
   end

--- a/test/toniq_test.exs
+++ b/test/toniq_test.exs
@@ -1,6 +1,7 @@
 defmodule ToniqTest do
   use ExUnit.Case
   import CaptureLog
+  alias Toniq.Job
 
   defmodule TestWorker do
     use Toniq.Worker
@@ -131,7 +132,10 @@ defmodule ToniqTest do
   test "can handle jobs from another VM for some actions (for easy administration of failed jobs)" do
     Toniq.KeepalivePersistence.register_vm("other")
     Toniq.KeepalivePersistence.update_alive_key("other", 1000)
-    job = Toniq.JobPersistence.store_job(TestWorker, [], "other")
+    job =
+      TestWorker
+      |> Job.new([])
+      |> Toniq.JobPersistence.store_job()
     Toniq.JobPersistence.mark_as_failed(job, "error", "other")
 
     assert Enum.count(Toniq.failed_jobs()) == 1


### PR DESCRIPTION
The `Job` structure is used internally.
Invoking the methods of `enqueue` is the same way.

The only change would be in the struct result.
```
> Toniq.enqueue(TestWorker, [name: "Joe"])
%Toniq.Job {arguments: [name: "Joe"],
  error: nil, id: 7, options: nil, version: 1,
  vm: "2be749b8-5ae7-11e8-a08f-4c327598015b", worker: TestWorker}
```
instead of the map
```
> Toniq.enqueue(TestWorker, [name: "Joe"])
%{arguments: [name: "Joe"], id: 7, version: 1,
 vm: "2be749b8-5ae7-11e8-a08f-4c327598015b", worker: TestWorker}
```

Using this structure I will create an adapter for `JobPersistance`