### PR TITLE
Replace `uuid` by `elixir_uuid`

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Toniq.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger, :uuid, :exredis], mod: {Toniq, []}]
+    [applications: [:logger, :exredis], mod: {Toniq, []}]
   end
 
   # Dependencies can be Hex packages:
@@ -33,7 +33,7 @@ defmodule Toniq.Mixfile do
   defp deps do
     [
       {:exredis, ">= 0.1.1"},
-      {:uuid, "~> 1.0"},
+      {:elixir_uuid, "~> 1.2.0"},
       {:ex_doc, ">= 0.0.0", only: :dev},
       {:mix_test_watch, "~> 0.5", only: :dev, runtime: false},
       {:retry, "~> 0.5.0", only: :test}

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
+  "elixir_uuid": {:hex, :elixir_uuid, "1.2.0", "ff26e938f95830b1db152cb6e594d711c10c02c6391236900ddd070a6b01271d", [:mix], [], "hexpm"},
   "eredis": {:hex, :eredis, "1.0.8", "ab4fda1c4ba7fbe6c19c26c249dc13da916d762502c4b4fa2df401a8d51c5364", [:rebar], []},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "exredis": {:hex, :exredis, "0.2.5", "34d02fa9ef32174cbd790b166746f91b3dbc131ce37a2d9a2451e8bba164b423", [:mix], [{:eredis, ">= 1.0.8", [hex: :eredis, optional: false]}]},


### PR DESCRIPTION
Because `elixir_uuid` is the new name because of package name
collisions.
see https://github.com/zyro/elixir-uuid for more information.